### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/spkl/Diffs/security/code-scanning/2](https://github.com/spkl/Diffs/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/dotnet.yml` at the workflow root (top-level), so it applies to all jobs unless overridden.  
For this workflow, the least-privilege baseline is:

- `contents: read`

This is sufficient for `actions/checkout` and build/test/format steps shown, and does not change existing functionality.

Edit region: immediately after the `on:` trigger block (after line 10 in the provided snippet), before `jobs:`.

No imports, methods, or additional definitions are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
