### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -5,6 +5,9 @@ on:
     types: [ published ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   publish:
 


### PR DESCRIPTION
Potential fix for [https://github.com/spkl/Diffs/security/code-scanning/1](https://github.com/spkl/Diffs/security/code-scanning/1)

Add an explicit `permissions` block with least privilege to the workflow.  
Best fix here: define workflow-level permissions right after the `on` section so all jobs inherit it unless overridden. For this workflow, `contents: read` is sufficient for `actions/checkout` and does not alter functional behavior of restore/pack/publish steps (NuGet publishing uses `secrets.NUGET_ORG_API_KEY`, not `GITHUB_TOKEN` write scopes).

Change only `.github/workflows/nuget.yml` by inserting:

```yml
permissions:
  contents: read
```

between the existing trigger section and `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
